### PR TITLE
Count visits with GoatCounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ grid for everything below it.
 Themes swap via `color-scheme`, which the OS sets and `[data-theme]` overrides,
 so there is no second copy of the palette to keep in sync.
 
+## Analytics
+
+Visits are counted by [GoatCounter](https://www.goatcounter.com), free for
+personal sites. The dashboard is at <https://benemdon.goatcounter.com>. It sets
+no cookies, stores no personal data and needs no consent banner, and the whole
+integration is the two script tags at the bottom of `index.html`'s `<head>` —
+still no build step.
+
+The site code in `data-goatcounter` is public, and has to be: anything counting
+visits from the browser names its destination in the page source. It is a
+write-only endpoint, not a key — it cannot read the dashboard, so putting it in
+a GitHub secret would hide it from the repo and not from anyone viewing source.
+The one thing it does allow is a mirrored copy of the page reporting into the
+same dashboard, which the hostname check in the `path` callback blocks. **Moving
+to a custom domain means adding that hostname there, or counting stops.**
+
+Append `#toggle-goatcounter` to the URL once to stop counting your own visits on
+that browser.
+
 ## Running it
 
 Any static server will do:

--- a/index.html
+++ b/index.html
@@ -65,6 +65,40 @@
     <link rel="stylesheet" href="assets/css/base.css" />
     <link rel="stylesheet" href="assets/css/layout.css" />
     <link rel="stylesheet" href="assets/css/components.css" />
+
+    <!-- Visit counting: GoatCounter. No cookies, no fingerprinting, no
+         persistent identifier, nothing personal stored — so there is nothing
+         to consent to and no banner to show.
+
+         The site code in data-goatcounter is public on purpose. It is a
+         write-only endpoint that hits are posted to, not a key, and it grants
+         no read access to the dashboard. Anything that counts visits from the
+         browser has to name its destination in the page source; there is no
+         version of this that stays private.
+
+         What that does leave open is someone pointing a mirror of this page at
+         the same endpoint, so the path callback below drops any hit that did
+         not come from the real host. It has to live in `path` and not in
+         `filter`: count.js assigns over `goatcounter.filter` when it loads, but
+         reads `goatcounter.path`, and a null path aborts the hit. If this site
+         ever moves to a custom domain, add that hostname here or counting stops.
+
+         count.js already skips localhost, file://, iframes and prerenders. It
+         does not check Do Not Track, so that check is here too. -->
+    <script>
+      window.goatcounter = {
+        path(p) {
+          if (location.hostname !== "benemdon.github.io") return null;
+          if (navigator.doNotTrack === "1" || navigator.globalPrivacyControl) return null;
+          return p;
+        },
+      };
+    </script>
+    <script
+      data-goatcounter="https://benemdon.goatcounter.com/count"
+      async
+      src="https://gc.zgo.at/count.js"
+    ></script>
   </head>
 
   <body>


### PR DESCRIPTION
Adds cookieless visit counting to the site. GoatCounter is free for
personal sites, stores no personal data and needs no consent banner, and
the integration is two script tags, so the site keeps its no-build-step
property.

The site code in data-goatcounter is public by necessity: anything that
counts from the browser names its endpoint in the page source. It is
write-only and grants no dashboard access, so there is no secret here to
store. What it does allow is a mirrored copy of the page reporting into
the same dashboard, so the path callback drops hits from any other
hostname. The check lives in `path` rather than `filter` because count.js
assigns over `goatcounter.filter` on load but reads `goatcounter.path`,
and a null path aborts the hit.

count.js already skips localhost, file://, iframes and prerenders. It does
not check Do Not Track, so that check is here too.

Verified in Chromium against a stubbed endpoint: a beacon fires on
benemdon.github.io, and none fires from another hostname, under Do Not
Track, or under Global Privacy Control.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GGUqZLUgUgenzQFgzU57TC